### PR TITLE
Add support for docker-compose v2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ tasks {
     }
 
     register<Jar>("sourceJar") {
-        from(sourceSets.main.get().allJava)
+        from(sourceSets.main.get().allSource)
         archiveClassifier.set("sources")
     }
 

--- a/src/main/kotlin/com/meltwater/docker/compose/DockerCompose.kt
+++ b/src/main/kotlin/com/meltwater/docker/compose/DockerCompose.kt
@@ -13,7 +13,6 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
-import java.util.HashMap
 import java.util.regex.Pattern
 import java.util.stream.Collectors
 import kotlin.concurrent.thread
@@ -23,9 +22,14 @@ import kotlin.concurrent.thread
  *
  * After initialization it is possible to start, stop, inspect and kill the containers that are configured in the yaml file.
  */
-class DockerCompose private constructor(private val prefix: String,
-                                        private val env: HashMap<String, String>,
-                                        private val dockerComposeFilename: String) {
+class DockerCompose private constructor(
+    prefix: String,
+    private val env: HashMap<String, String>,
+    private val dockerComposeFilename: String
+) {
+
+    // docker-compose 2.2.2 seems to use lowercase internally and have issues with uppercase
+    private val prefix = prefix.lowercase()
 
     companion object {
 

--- a/src/main/kotlin/com/meltwater/docker/compose/data/ComposeResults.kt
+++ b/src/main/kotlin/com/meltwater/docker/compose/data/ComposeResults.kt
@@ -4,10 +4,17 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class InspectData(
         @param:JsonProperty("Id") val id: String,
-        @param:JsonProperty("Name") val name: String,
+        @param:JsonProperty("Name") val rawName: String,
         @param:JsonProperty("State") val state: ContainerState,
         @param:JsonProperty("HostConfig") val hostConfig: HostConfig,
         @param:JsonProperty("NetworkSettings") val networkSettings: NetworkSettings) {
+
+    val name: String = if (rawName.startsWith('/')) {
+        rawName.substring(1)
+    } else {
+        rawName
+    }
+
     /**
      * Finds a single binding for an internal TCP port
      */

--- a/src/main/kotlin/com/meltwater/docker/compose/data/PsResult.kt
+++ b/src/main/kotlin/com/meltwater/docker/compose/data/PsResult.kt
@@ -4,12 +4,8 @@ class PsResult(prefix: String, private val rawResult: List<InspectData>) {
 
     private val result: Map<String, InspectData> = parse(prefix, rawResult)
 
-    fun getData(shortName: String): InspectData {
-        return result[shortName] ?: throw IllegalArgumentException("shortName not found: $shortName")
-    }
-
-    fun getContainerName(shortName: String): String {
-        return getData(shortName).name
+    fun getData(shortName: String): InspectData? {
+        return result[shortName]
     }
 
     fun asList(): List<InspectData> {

--- a/src/main/kotlin/com/meltwater/docker/compose/data/PsResult.kt
+++ b/src/main/kotlin/com/meltwater/docker/compose/data/PsResult.kt
@@ -1,0 +1,45 @@
+package com.meltwater.docker.compose.data
+
+class PsResult(prefix: String, private val rawResult: List<InspectData>) {
+
+    private val result: Map<String, InspectData> = parse(prefix, rawResult)
+
+    fun getData(shortName: String): InspectData {
+        return result[shortName] ?: throw IllegalArgumentException("shortName not found: $shortName")
+    }
+
+    fun getContainerName(shortName: String): String {
+        return getData(shortName).name
+    }
+
+    fun asList(): List<InspectData> {
+        return rawResult
+    }
+
+    companion object {
+        private fun parse(prefix: String, rawResult: List<InspectData>): Map<String, InspectData> {
+            val result = HashMap<String, InspectData>()
+            val shortNameRegex = Regex("${prefix}[-_](.*)[-_](\\d+)")
+
+            rawResult.forEach {
+                val shortName = parseShortName(shortNameRegex, it.name)
+                if (result.contains(shortName)) {
+                    throw IllegalStateException("Spawned two containers with the same shortName: $shortName")
+                }
+                result[shortName] = it
+            }
+
+            return result
+        }
+
+        private fun parseShortName(shortNameRegex: Regex, containerName: String): String {
+            val matchResult = shortNameRegex.matchEntire(containerName)
+                ?: throw IllegalStateException("Failed to parse short name for container $containerName")
+
+            val name = matchResult.groupValues[1]
+            val index = matchResult.groupValues[2]
+            return "$name-$index"
+        }
+    }
+
+}

--- a/src/test/groovy/com/meltwater/docker/compose/DockerComposeKillTest.groovy
+++ b/src/test/groovy/com/meltwater/docker/compose/DockerComposeKillTest.groovy
@@ -1,0 +1,49 @@
+package com.meltwater.docker.compose
+
+
+import com.meltwater.docker.compose.data.PsResult
+import org.slf4j.LoggerFactory
+import spock.lang.Shared
+import spock.lang.Specification
+
+class DockerComposeKillTest extends Specification {
+    @Shared
+    private static DockerCompose compose
+
+    void setupSpec() throws Exception {
+        compose = new DockerCompose("simple-busybox.yml", "composekilltest", new HashMap<String, String>())
+    }
+
+    void cleanupSpec() throws Exception {
+        try {
+            compose.kill()
+        }
+        catch (RuntimeException e) {
+            if (e.message.contains("Cannot kill container") && e.message.endsWith(" is not running\n")) {
+                // In docker compose v2, kill fails when a container is already killed. Treat as OK for this test
+                LoggerFactory.getLogger(DockerComposeKillTest.class)
+                        .warn("Kill failed, probably because container was already killed. Swallowing exception", e)
+            } else {
+                throw e
+            }
+        }
+        compose.rm() // TODO: Investigate this, seems to have no effect?
+    }
+
+    def 'kill single container'() {
+        given:
+            def upResult = compose.up(Recreate.DEFAULT)
+        when:
+            compose.kill(upResult.getContainerName("foo-1"))
+        then:
+            PsResult inspectData = compose.ps()
+            def foo = inspectData.getData("foo-1")
+            def bar = inspectData.getData("bar-1")
+            def barHost = inspectData.getData("bar-host-1")
+
+            !foo.state.running
+            bar.state.running
+            barHost.state.running
+    }
+
+}

--- a/src/test/groovy/com/meltwater/docker/compose/DockerComposeKillTest.groovy
+++ b/src/test/groovy/com/meltwater/docker/compose/DockerComposeKillTest.groovy
@@ -27,7 +27,10 @@ class DockerComposeKillTest extends Specification {
                 throw e
             }
         }
-        compose.rm() // TODO: Investigate this, seems to have no effect?
+
+        // rm appears to be flaky if ran too fast after the partially failed kill, sometimes not removing all containers.
+        Thread.sleep(1000)
+        compose.rm()
     }
 
     def 'kill single container'() {

--- a/src/test/groovy/com/meltwater/docker/compose/DockerComposeKillTest.groovy
+++ b/src/test/groovy/com/meltwater/docker/compose/DockerComposeKillTest.groovy
@@ -11,7 +11,7 @@ class DockerComposeKillTest extends Specification {
     private static DockerCompose compose
 
     void setupSpec() throws Exception {
-        compose = new DockerCompose("simple-busybox.yml", "composekilltest", new HashMap<String, String>())
+        compose = new DockerCompose("simple-busybox.yml", "composeKillTest", new HashMap<String, String>())
     }
 
     void cleanupSpec() throws Exception {
@@ -37,7 +37,7 @@ class DockerComposeKillTest extends Specification {
         given:
             def upResult = compose.up(Recreate.DEFAULT)
         when:
-            compose.kill(upResult.getContainerName("foo-1"))
+            compose.kill(upResult.getData("foo-1").name)
         then:
             PsResult inspectData = compose.ps()
             def foo = inspectData.getData("foo-1")

--- a/src/test/groovy/com/meltwater/docker/compose/DockerComposeTest.groovy
+++ b/src/test/groovy/com/meltwater/docker/compose/DockerComposeTest.groovy
@@ -1,6 +1,5 @@
 package com.meltwater.docker.compose
 
-import com.meltwater.docker.compose.data.InspectData
 import com.meltwater.docker.compose.data.PsResult
 import spock.lang.Shared
 import spock.lang.Specification

--- a/src/test/groovy/com/meltwater/docker/compose/data/PsResultTest.groovy
+++ b/src/test/groovy/com/meltwater/docker/compose/data/PsResultTest.groovy
@@ -1,0 +1,31 @@
+package com.meltwater.docker.compose.data
+
+import spock.lang.Specification
+
+class PsResultTest extends Specification {
+
+    def 'test parseShortName'() {
+        when:
+            def result = new PsResult("prefix123",
+                    [stubData("prefix123-my-name-1"),
+                     stubData("prefix123_with_underscore_1"),
+                     stubData("prefix123-second-2"),
+                     stubData("prefix123_third_3")])
+        then:
+            result.getData("my-name-1").name == "prefix123-my-name-1"
+            result.getData("with_underscore-1").name == "prefix123_with_underscore_1"
+            result.getData("second-2").name == "prefix123-second-2"
+            result.getData("third-3").name == "prefix123_third_3"
+    }
+
+    static def stubData(name) {
+        return new InspectData(
+                "",
+                name,
+                new ContainerState(true, true),
+                new HostConfig("", [:]),
+                new NetworkSettings([:])
+        )
+    }
+
+}


### PR DESCRIPTION
The naming scheme of created containers changed between docker-compose v1 and v2 (the version of the software itself, not the version in the yaml files). The change is that dashes are used instead of underscores in generated container names. Example: `prefix_my-service_1` -> `prefix-my-service-1`. To support both cases, the name has been normalized in `PsResult`.