### PR TITLE
Add ability to prune unused resources

### DIFF
--- a/src/main/kotlin/com/meltwater/docker/compose/Docker.kt
+++ b/src/main/kotlin/com/meltwater/docker/compose/Docker.kt
@@ -9,7 +9,16 @@ import com.meltwater.docker.compose.data.InspectData
 
 object Docker {
 
-    private var mapper: ObjectMapper = ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    private var mapper: ObjectMapper =
+        ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+    object System {
+        fun prune() = exec("system prune --force")
+
+        fun pruneAll() = exec("system prune --force --all")
+
+        fun pruneVolumes() = exec("system prune --force --volumes")
+    }
 
     fun kill(containerName: String) {
         exec("kill $containerName")


### PR DESCRIPTION
Adds the functionality to prune dangling resources in the system.

This would be useful if one needs to cleanup unused networks or volumes after Docker Compose is done.
