### PR TITLE
Use a recently built Docker image in tests

### DIFF
--- a/src/test/resources/simple-busybox.yml
+++ b/src/test/resources/simple-busybox.yml
@@ -1,19 +1,19 @@
 version: '2.1'
 services:
   foo:
-    image: busybox:1.24.1
+    image: busybox:1.37.0
     command: sh -c "while true; do sleep 1; done"
     ports:
       - "9090"
       - "9091"
   bar:
-    image: busybox:1.24.1
+    image: busybox:1.37.0
     command: sh -c "while true; do sleep 1; done"
     ports:
       - "8080"
       - "8081"
   bar-host:
-    image: busybox:1.24.1
+    image: busybox:1.37.0
     command: sh -c "while true; do sleep 1; done"
     network_mode: "host"
 


### PR DESCRIPTION
- The Docker image format has evolved and the current test images uses a Docker image manifest which is disabled in recent Docker engine versions
- Use lastest release to get an image supported by the Docker engine version in the current test infrastructure